### PR TITLE
Instance registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,8 @@ The following keys can be specified on a private frontend.
 - `mode` - Specifies the mode the load-balancer will be configured for for this frontend. Mode can be `http` (default) or `tcp`.
 Frontends using `tcp` mode will offer TCP over TLS connections, using SNI to identify the correct task to forward the request to.
 The connection from the load-balancer to the task will use TCP only.
+- `register-instance` - If set, instances of this task will also be registered in the load-balancer under an instance specific
+name. This enables access to individual instances, in addition to load-balanced access to all instances of a task.
 
 #### Secrets
 

--- a/config/base.hcl
+++ b/config/base.hcl
@@ -21,7 +21,7 @@ job "base" {
 		}
 
 		task "lb" {
-			image = "pulcy/robin:0.14.0"
+			image = "pulcy/robin:0.15.0"
 			ports = ["0.0.0.0:80:80", "{{private_ipv4}}:81:81", "{{private_ipv4}}:82:82", "0.0.0.0:443:443", "0.0.0.0:7088:7088"]
 			volumes = "/tmp/base/lb/certs/:/certs/"
 			secret "secret/base/lb/stats-password" {

--- a/config/base.hcl
+++ b/config/base.hcl
@@ -12,7 +12,9 @@ job "base" {
 		global = true
 
 		task "certificates" {
-			image = "pulcy/pct:0.4.0"
+			type = "oneshot"
+			image = "pulcy/pct:0.4.1"
+			volumes = "/tmp/base/lb/certs/:/certs/"
 			secret "secret/base/lb/certificates-passphrase" {
                 environment = "PASSPHRASE"
             }
@@ -21,7 +23,7 @@ job "base" {
 		task "lb" {
 			image = "pulcy/robin:0.14.0"
 			ports = ["0.0.0.0:80:80", "{{private_ipv4}}:81:81", "{{private_ipv4}}:82:82", "0.0.0.0:443:443", "0.0.0.0:7088:7088"]
-			volumes-from = "certificates"
+			volumes = "/tmp/base/lb/certs/:/certs/"
 			secret "secret/base/lb/stats-password" {
                 environment = "STATS_PASSWORD"
             }

--- a/jobs/frontend.go
+++ b/jobs/frontend.go
@@ -30,10 +30,11 @@ type PublicFrontEnd struct {
 
 // PrivateFrontEnd contains a specification of a private HTTP(S) frontend.
 type PrivateFrontEnd struct {
-	Port   int    `json:"port,omitempty" mapstructure:"port,omitempty"`
-	Users  []User `json:"users,omitempty"`
-	Weight int    `json:"weight,omitempty" mapstructure:"weight,omitempty"`
-	Mode   string `json:"mode,omitempty" mapstructure:"mode,omitempty"`
+	Port             int    `json:"port,omitempty" mapstructure:"port,omitempty"`
+	Users            []User `json:"users,omitempty"`
+	Weight           int    `json:"weight,omitempty" mapstructure:"weight,omitempty"`
+	Mode             string `json:"mode,omitempty" mapstructure:"mode,omitempty"`
+	RegisterInstance bool   `json:"register-instance,omitempty" mapstructure:"register-instance,omitempty"`
 }
 
 // User contains a user name+password who has access to a frontend

--- a/jobs/instance_name.go
+++ b/jobs/instance_name.go
@@ -1,0 +1,42 @@
+// Copyright (c) 2016 Pulcy.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package jobs
+
+import (
+	"strconv"
+
+	"github.com/juju/errgo"
+)
+
+type InstanceName string
+
+func (in InstanceName) String() string {
+	return string(in)
+}
+
+// IsEmpty returns true if the given instance name is empty, false otherwise.
+func (in InstanceName) IsEmpty() bool {
+	return in == ""
+}
+
+func (in InstanceName) Validate() error {
+	if in == "" {
+		return nil
+	}
+	if _, err := strconv.Atoi(string(in)); err != nil {
+		return maskAny(errgo.WithCausef(nil, InvalidNameError, "instance name must be an integer, got '%s'", in))
+	}
+	return nil
+}

--- a/jobs/link.go
+++ b/jobs/link.go
@@ -46,7 +46,7 @@ func (ln LinkName) String() string {
 
 // PrivateDomainName returns the DNS name (in the private namespace) for the given link name.
 func (ln LinkName) PrivateDomainName() string {
-	return fmt.Sprintf("%s.private", ln.String())
+	return fmt.Sprintf("%s.private", strings.Replace(ln.String(), "@", ".", -1))
 }
 
 // Validate checks if a link name follows a valid format

--- a/jobs/link.go
+++ b/jobs/link.go
@@ -22,22 +22,26 @@ import (
 )
 
 // LinkName is a name of a link consisting of:
-// <job>.<task> or
-// <job>.<taskgroup>.<task>
+// <job>.<task>[@<instance>] or
+// <job>.<taskgroup>.<task>[@instance]
 type LinkName string
 
 // NewLinkName assembles a link name from its elements.
-func NewLinkName(jn JobName, tgn TaskGroupName, tn TaskName) LinkName {
-	return LinkName(fmt.Sprintf("%s.%s.%s", jn, tgn, tn))
+func NewLinkName(jn JobName, tgn TaskGroupName, tn TaskName, in InstanceName) LinkName {
+	result := fmt.Sprintf("%s.%s.%s", jn, tgn, tn)
+	if !in.IsEmpty() {
+		result = fmt.Sprintf("%s@%s", result, in)
+	}
+	return LinkName(result)
 }
 
 // String returns a link name in format <job>.<taskgroup>.<task>
 func (ln LinkName) String() string {
-	jn, tgn, tn, err := ln.parse()
+	jn, tgn, tn, in, err := ln.parse()
 	if err != nil {
 		return ""
 	}
-	return fmt.Sprintf("%s.%s.%s", jn, tgn, tn)
+	return string(NewLinkName(jn, tgn, tn, in))
 }
 
 // PrivateDomainName returns the DNS name (in the private namespace) for the given link name.
@@ -47,12 +51,23 @@ func (ln LinkName) PrivateDomainName() string {
 
 // Validate checks if a link name follows a valid format
 func (ln LinkName) Validate() error {
-	_, _, _, err := ln.parse()
+	_, _, _, _, err := ln.parse()
 	return maskAny(err)
 }
 
-func (ln LinkName) parse() (JobName, TaskGroupName, TaskName, error) {
-	parts := strings.Split(string(ln), ".")
+func (ln LinkName) parse() (JobName, TaskGroupName, TaskName, InstanceName, error) {
+	var instanceName InstanceName
+	parts := strings.Split(string(ln), "@")
+	switch len(parts) {
+	case 1:
+		// Empty instance name
+	case 2:
+		instanceName = InstanceName(parts[1])
+	default:
+		return "", "", "", "", maskAny(errgo.WithCausef(nil, InvalidNameError, "unrecognized link '%s'", string(ln)))
+	}
+
+	parts = strings.Split(parts[0], ".")
 	var jobName JobName
 	var taskGroupName TaskGroupName
 	var taskName TaskName
@@ -66,24 +81,27 @@ func (ln LinkName) parse() (JobName, TaskGroupName, TaskName, error) {
 		taskGroupName = TaskGroupName(parts[1])
 		taskName = TaskName(parts[2])
 	default:
-		return "", "", "", maskAny(errgo.WithCausef(nil, InvalidNameError, "unrecognized link '%s'", string(ln)))
+		return "", "", "", "", maskAny(errgo.WithCausef(nil, InvalidNameError, "unrecognized link '%s'", string(ln)))
 	}
 	if err := jobName.Validate(); err != nil {
-		return "", "", "", maskAny(err)
+		return "", "", "", "", maskAny(err)
 	}
 	if err := taskGroupName.Validate(); err != nil {
-		return "", "", "", maskAny(err)
+		return "", "", "", "", maskAny(err)
 	}
 	if err := taskName.Validate(); err != nil {
-		return "", "", "", maskAny(err)
+		return "", "", "", "", maskAny(err)
 	}
-	return jobName, taskGroupName, taskName, nil
+	if err := instanceName.Validate(); err != nil {
+		return "", "", "", "", maskAny(err)
+	}
+	return jobName, taskGroupName, taskName, instanceName, nil
 }
 
 func (ln LinkName) normalize() LinkName {
-	jn, tgn, tn, err := ln.parse()
+	jn, tgn, tn, in, err := ln.parse()
 	if err != nil {
 		return ln
 	}
-	return NewLinkName(jn, tgn, tn)
+	return NewLinkName(jn, tgn, tn, in)
 }

--- a/jobs/task.go
+++ b/jobs/task.go
@@ -16,6 +16,7 @@ package jobs
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/juju/errgo"
@@ -162,7 +163,13 @@ func (t *Task) fullName() string {
 
 // privateDomainName returns the DNS name (in the private namespace) for the given task.
 func (t *Task) privateDomainName() string {
-	ln := NewLinkName(t.group.job.Name, t.group.Name, t.Name)
+	ln := NewLinkName(t.group.job.Name, t.group.Name, t.Name, "")
+	return ln.PrivateDomainName()
+}
+
+// instanceSpecificPrivateDomainName returns the DNS name (in the private namespace) for an instance of the given task.
+func (t *Task) instanceSpecificPrivateDomainName(scalingGroup uint) string {
+	ln := NewLinkName(t.group.job.Name, t.group.Name, t.Name, InstanceName(strconv.Itoa(int(scalingGroup))))
 	return ln.PrivateDomainName()
 }
 

--- a/jobs/test-fixtures/simple.hcl
+++ b/jobs/test-fixtures/simple.hcl
@@ -84,6 +84,7 @@ job "test" {
 		image = "couchdb:latest"
 		private-frontend {
 			port = 5984
+			register-instance = true
 		}
 	}
 

--- a/jobs/test-fixtures/simple.hcl.json
+++ b/jobs/test-fixtures/simple.hcl.json
@@ -11,7 +11,8 @@
             "name": "couchdb",
             "image": "couchdb:latest",
             "private-frontends": [{
-                "port": 5984
+                "port": 5984,
+                "register-instance": true
             }]
         }]
     }, {

--- a/jobs/test-fixtures/units/instance-count-1/secret.hcl/secrets-env_secrets-env_secrets-sc@1.service
+++ b/jobs/test-fixtures/units/instance-count-1/secret.hcl/secrets-env_secrets-env_secrets-sc@1.service
@@ -23,8 +23,8 @@ Environment="VOLCRT=/etc/pulcy/vault.crt:/etc/pulcy/vault.crt:ro"
 Environment="VOLMAC=/etc/machine-id:/etc/machine-id:ro"
 ExecStartPre=/usr/bin/mkdir -p /tmp/secrets/secrets-env_secrets-env_secrets-1
 ExecStartPre=/usr/bin/docker pull pulcy/vault-monkey:latest
-ExecStartPre=/usr/bin/docker run --rm -v ${SCROOT} -v ${VOLCRT} -v ${VOLCLS} -v ${VOLMAC} --env-file /etc/pulcy/vault.env $A00 pulcy/vault-monkey:latest extract file $A01 $A02 $A03
-ExecStart=/usr/bin/docker run --rm -v ${SCROOT} -v ${VOLCRT} -v ${VOLCLS} -v ${VOLMAC} --env-file /etc/pulcy/vault.env $A04 pulcy/vault-monkey:latest extract env $A05 $A06 $A07
+ExecStartPre=/usr/bin/docker run --rm --name secrets-env_secrets-env_secrets-1-sc -v ${SCROOT} -v ${VOLCRT} -v ${VOLCLS} -v ${VOLMAC} --env-file /etc/pulcy/vault.env $A00 pulcy/vault-monkey:latest extract file $A01 $A02 $A03
+ExecStart=/usr/bin/docker run --rm --name secrets-env_secrets-env_secrets-1-sc -v ${SCROOT} -v ${VOLCRT} -v ${VOLCLS} -v ${VOLMAC} --env-file /etc/pulcy/vault.env $A04 pulcy/vault-monkey:latest extract env $A05 $A06 $A07
 
 [X-Fleet]
 

--- a/jobs/test-fixtures/units/instance-count-1/simple.hcl/test-couchdb-couchdb-mn@1.service
+++ b/jobs/test-fixtures/units/instance-count-1/simple.hcl/test-couchdb-couchdb-mn@1.service
@@ -18,7 +18,7 @@ ExecStartPre=/usr/bin/docker pull couchdb:latest
 ExecStartPre=-/usr/bin/docker stop -t 10 test-couchdb-couchdb-1
 ExecStartPre=-/usr/bin/docker rm -f test-couchdb-couchdb-1
 ExecStart=/usr/bin/docker run --rm --name test-couchdb-couchdb-1 -P $A00 $A01 couchdb:latest
-ExecStartPost=/bin/sh -c 'echo eyJzZWxlY3RvcnMiOlt7ImRvbWFpbiI6InRlc3QuY291Y2hkYi5jb3VjaGRiQDEucHJpdmF0ZSIsInBvcnQiOjU5ODQsInByaXZhdGUiOnRydWV9XSwic2VydmljZSI6InRlc3QtY291Y2hkYi1jb3VjaGRiLTEifQ== | base64 -d | /usr/bin/etcdctl set /pulcy/frontend/test-couchdb-couchdb-1-inst'
+ExecStartPost=/bin/sh -c 'echo eyJzZWxlY3RvcnMiOlt7ImRvbWFpbiI6InRlc3QuY291Y2hkYi5jb3VjaGRiLjEucHJpdmF0ZSIsInBvcnQiOjU5ODQsInByaXZhdGUiOnRydWV9XSwic2VydmljZSI6InRlc3QtY291Y2hkYi1jb3VjaGRiLTEifQ== | base64 -d | /usr/bin/etcdctl set /pulcy/frontend/test-couchdb-couchdb-1-inst'
 ExecStartPost=/bin/sh -c 'echo eyJzZWxlY3RvcnMiOlt7ImRvbWFpbiI6InRlc3QuY291Y2hkYi5jb3VjaGRiLnByaXZhdGUiLCJwb3J0Ijo1OTg0LCJwcml2YXRlIjp0cnVlfV0sInNlcnZpY2UiOiJ0ZXN0LWNvdWNoZGItY291Y2hkYiJ9 | base64 -d | /usr/bin/etcdctl set /pulcy/frontend/test-couchdb-couchdb-1'
 ExecStop=-/usr/bin/etcdctl rm /pulcy/frontend/test-couchdb-couchdb-1
 ExecStop=-/usr/bin/etcdctl rm /pulcy/frontend/test-couchdb-couchdb-1-inst
@@ -30,5 +30,5 @@ MachineMetadata="core=true"
 
 [X-testproject]
 GeneratedBy="testproject test-version, build test-build"
-FrontEndRegistration-i="/pulcy/frontend/test-couchdb-couchdb-1-inst={\"selectors\":[{\"domain\":\"test.couchdb.couchdb@1.private\",\"port\":5984,\"private\":true}],\"service\":\"test-couchdb-couchdb-1\"}"
+FrontEndRegistration-i="/pulcy/frontend/test-couchdb-couchdb-1-inst={\"selectors\":[{\"domain\":\"test.couchdb.couchdb.1.private\",\"port\":5984,\"private\":true}],\"service\":\"test-couchdb-couchdb-1\"}"
 FrontEndRegistration="/pulcy/frontend/test-couchdb-couchdb-1={\"selectors\":[{\"domain\":\"test.couchdb.couchdb.private\",\"port\":5984,\"private\":true}],\"service\":\"test-couchdb-couchdb\"}"

--- a/jobs/test-fixtures/units/instance-count-1/simple.hcl/test-couchdb-couchdb-mn@1.service
+++ b/jobs/test-fixtures/units/instance-count-1/simple.hcl/test-couchdb-couchdb-mn@1.service
@@ -18,8 +18,10 @@ ExecStartPre=/usr/bin/docker pull couchdb:latest
 ExecStartPre=-/usr/bin/docker stop -t 10 test-couchdb-couchdb-1
 ExecStartPre=-/usr/bin/docker rm -f test-couchdb-couchdb-1
 ExecStart=/usr/bin/docker run --rm --name test-couchdb-couchdb-1 -P $A00 $A01 couchdb:latest
+ExecStartPost=/bin/sh -c 'echo eyJzZWxlY3RvcnMiOlt7ImRvbWFpbiI6InRlc3QuY291Y2hkYi5jb3VjaGRiQDEucHJpdmF0ZSIsInBvcnQiOjU5ODQsInByaXZhdGUiOnRydWV9XSwic2VydmljZSI6InRlc3QtY291Y2hkYi1jb3VjaGRiLTEifQ== | base64 -d | /usr/bin/etcdctl set /pulcy/frontend/test-couchdb-couchdb-1-inst'
 ExecStartPost=/bin/sh -c 'echo eyJzZWxlY3RvcnMiOlt7ImRvbWFpbiI6InRlc3QuY291Y2hkYi5jb3VjaGRiLnByaXZhdGUiLCJwb3J0Ijo1OTg0LCJwcml2YXRlIjp0cnVlfV0sInNlcnZpY2UiOiJ0ZXN0LWNvdWNoZGItY291Y2hkYiJ9 | base64 -d | /usr/bin/etcdctl set /pulcy/frontend/test-couchdb-couchdb-1'
 ExecStop=-/usr/bin/etcdctl rm /pulcy/frontend/test-couchdb-couchdb-1
+ExecStop=-/usr/bin/etcdctl rm /pulcy/frontend/test-couchdb-couchdb-1-inst
 ExecStop=-/usr/bin/docker stop -t 10 test-couchdb-couchdb-1
 ExecStopPost=-/usr/bin/docker rm -f test-couchdb-couchdb-1
 
@@ -28,4 +30,5 @@ MachineMetadata="core=true"
 
 [X-testproject]
 GeneratedBy="testproject test-version, build test-build"
+FrontEndRegistration-i="/pulcy/frontend/test-couchdb-couchdb-1-inst={\"selectors\":[{\"domain\":\"test.couchdb.couchdb@1.private\",\"port\":5984,\"private\":true}],\"service\":\"test-couchdb-couchdb-1\"}"
 FrontEndRegistration="/pulcy/frontend/test-couchdb-couchdb-1={\"selectors\":[{\"domain\":\"test.couchdb.couchdb.private\",\"port\":5984,\"private\":true}],\"service\":\"test-couchdb-couchdb\"}"

--- a/jobs/test-fixtures/units/instance-count-3/secret.hcl/secrets-env_secrets-env_secrets-sc@1.service
+++ b/jobs/test-fixtures/units/instance-count-3/secret.hcl/secrets-env_secrets-env_secrets-sc@1.service
@@ -23,8 +23,8 @@ Environment="VOLCRT=/etc/pulcy/vault.crt:/etc/pulcy/vault.crt:ro"
 Environment="VOLMAC=/etc/machine-id:/etc/machine-id:ro"
 ExecStartPre=/usr/bin/mkdir -p /tmp/secrets/secrets-env_secrets-env_secrets-1
 ExecStartPre=/usr/bin/docker pull pulcy/vault-monkey:latest
-ExecStartPre=/usr/bin/docker run --rm -v ${SCROOT} -v ${VOLCRT} -v ${VOLCLS} -v ${VOLMAC} --env-file /etc/pulcy/vault.env $A00 pulcy/vault-monkey:latest extract file $A01 $A02 $A03
-ExecStart=/usr/bin/docker run --rm -v ${SCROOT} -v ${VOLCRT} -v ${VOLCLS} -v ${VOLMAC} --env-file /etc/pulcy/vault.env $A04 pulcy/vault-monkey:latest extract env $A05 $A06 $A07
+ExecStartPre=/usr/bin/docker run --rm --name secrets-env_secrets-env_secrets-1-sc -v ${SCROOT} -v ${VOLCRT} -v ${VOLCLS} -v ${VOLMAC} --env-file /etc/pulcy/vault.env $A00 pulcy/vault-monkey:latest extract file $A01 $A02 $A03
+ExecStart=/usr/bin/docker run --rm --name secrets-env_secrets-env_secrets-1-sc -v ${SCROOT} -v ${VOLCRT} -v ${VOLCLS} -v ${VOLMAC} --env-file /etc/pulcy/vault.env $A04 pulcy/vault-monkey:latest extract env $A05 $A06 $A07
 
 [X-Fleet]
 

--- a/jobs/test-fixtures/units/instance-count-3/simple.hcl/test-couchdb-couchdb-mn@1.service
+++ b/jobs/test-fixtures/units/instance-count-3/simple.hcl/test-couchdb-couchdb-mn@1.service
@@ -18,8 +18,10 @@ ExecStartPre=/usr/bin/docker pull couchdb:latest
 ExecStartPre=-/usr/bin/docker stop -t 10 test-couchdb-couchdb-1
 ExecStartPre=-/usr/bin/docker rm -f test-couchdb-couchdb-1
 ExecStart=/usr/bin/docker run --rm --name test-couchdb-couchdb-1 -P $A00 $A01 couchdb:latest
+ExecStartPost=/bin/sh -c 'echo eyJzZWxlY3RvcnMiOlt7ImRvbWFpbiI6InRlc3QuY291Y2hkYi5jb3VjaGRiQDEucHJpdmF0ZSIsInBvcnQiOjU5ODQsInByaXZhdGUiOnRydWV9XSwic2VydmljZSI6InRlc3QtY291Y2hkYi1jb3VjaGRiLTEifQ== | base64 -d | /usr/bin/etcdctl set /pulcy/frontend/test-couchdb-couchdb-1-inst'
 ExecStartPost=/bin/sh -c 'echo eyJzZWxlY3RvcnMiOlt7ImRvbWFpbiI6InRlc3QuY291Y2hkYi5jb3VjaGRiLnByaXZhdGUiLCJwb3J0Ijo1OTg0LCJwcml2YXRlIjp0cnVlfV0sInNlcnZpY2UiOiJ0ZXN0LWNvdWNoZGItY291Y2hkYiJ9 | base64 -d | /usr/bin/etcdctl set /pulcy/frontend/test-couchdb-couchdb-1'
 ExecStop=-/usr/bin/etcdctl rm /pulcy/frontend/test-couchdb-couchdb-1
+ExecStop=-/usr/bin/etcdctl rm /pulcy/frontend/test-couchdb-couchdb-1-inst
 ExecStop=-/usr/bin/docker stop -t 10 test-couchdb-couchdb-1
 ExecStopPost=-/usr/bin/docker rm -f test-couchdb-couchdb-1
 
@@ -29,4 +31,5 @@ MachineMetadata="core=true"
 
 [X-testproject]
 GeneratedBy="testproject test-version, build test-build"
+FrontEndRegistration-i="/pulcy/frontend/test-couchdb-couchdb-1-inst={\"selectors\":[{\"domain\":\"test.couchdb.couchdb@1.private\",\"port\":5984,\"private\":true}],\"service\":\"test-couchdb-couchdb-1\"}"
 FrontEndRegistration="/pulcy/frontend/test-couchdb-couchdb-1={\"selectors\":[{\"domain\":\"test.couchdb.couchdb.private\",\"port\":5984,\"private\":true}],\"service\":\"test-couchdb-couchdb\"}"

--- a/jobs/test-fixtures/units/instance-count-3/simple.hcl/test-couchdb-couchdb-mn@1.service
+++ b/jobs/test-fixtures/units/instance-count-3/simple.hcl/test-couchdb-couchdb-mn@1.service
@@ -18,7 +18,7 @@ ExecStartPre=/usr/bin/docker pull couchdb:latest
 ExecStartPre=-/usr/bin/docker stop -t 10 test-couchdb-couchdb-1
 ExecStartPre=-/usr/bin/docker rm -f test-couchdb-couchdb-1
 ExecStart=/usr/bin/docker run --rm --name test-couchdb-couchdb-1 -P $A00 $A01 couchdb:latest
-ExecStartPost=/bin/sh -c 'echo eyJzZWxlY3RvcnMiOlt7ImRvbWFpbiI6InRlc3QuY291Y2hkYi5jb3VjaGRiQDEucHJpdmF0ZSIsInBvcnQiOjU5ODQsInByaXZhdGUiOnRydWV9XSwic2VydmljZSI6InRlc3QtY291Y2hkYi1jb3VjaGRiLTEifQ== | base64 -d | /usr/bin/etcdctl set /pulcy/frontend/test-couchdb-couchdb-1-inst'
+ExecStartPost=/bin/sh -c 'echo eyJzZWxlY3RvcnMiOlt7ImRvbWFpbiI6InRlc3QuY291Y2hkYi5jb3VjaGRiLjEucHJpdmF0ZSIsInBvcnQiOjU5ODQsInByaXZhdGUiOnRydWV9XSwic2VydmljZSI6InRlc3QtY291Y2hkYi1jb3VjaGRiLTEifQ== | base64 -d | /usr/bin/etcdctl set /pulcy/frontend/test-couchdb-couchdb-1-inst'
 ExecStartPost=/bin/sh -c 'echo eyJzZWxlY3RvcnMiOlt7ImRvbWFpbiI6InRlc3QuY291Y2hkYi5jb3VjaGRiLnByaXZhdGUiLCJwb3J0Ijo1OTg0LCJwcml2YXRlIjp0cnVlfV0sInNlcnZpY2UiOiJ0ZXN0LWNvdWNoZGItY291Y2hkYiJ9 | base64 -d | /usr/bin/etcdctl set /pulcy/frontend/test-couchdb-couchdb-1'
 ExecStop=-/usr/bin/etcdctl rm /pulcy/frontend/test-couchdb-couchdb-1
 ExecStop=-/usr/bin/etcdctl rm /pulcy/frontend/test-couchdb-couchdb-1-inst
@@ -31,5 +31,5 @@ MachineMetadata="core=true"
 
 [X-testproject]
 GeneratedBy="testproject test-version, build test-build"
-FrontEndRegistration-i="/pulcy/frontend/test-couchdb-couchdb-1-inst={\"selectors\":[{\"domain\":\"test.couchdb.couchdb@1.private\",\"port\":5984,\"private\":true}],\"service\":\"test-couchdb-couchdb-1\"}"
+FrontEndRegistration-i="/pulcy/frontend/test-couchdb-couchdb-1-inst={\"selectors\":[{\"domain\":\"test.couchdb.couchdb.1.private\",\"port\":5984,\"private\":true}],\"service\":\"test-couchdb-couchdb-1\"}"
 FrontEndRegistration="/pulcy/frontend/test-couchdb-couchdb-1={\"selectors\":[{\"domain\":\"test.couchdb.couchdb.private\",\"port\":5984,\"private\":true}],\"service\":\"test-couchdb-couchdb\"}"


### PR DESCRIPTION
Added `register-instance` option to private frontends.

This enables access to specific instances in addition to load-balanced access to all instances of a task.