### PR TITLE
Cluster2

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ Each name must be a fully qualified task name (job.group.task).
 - `frontend` - Contains a public load-balancer registration. This configures the load-balancer to forward certain requests from the public network interface(s) of the cluster to this task. See [Frontends](#frontends).
 - `private-frontend` - Contains a private load-balancer registration. This configures the load-balancer to forward certain requests from the private network interface(s) of the cluster to this task. See [Frontends](#frontends).
 - `secret` - Contains a specification for a secret value to be fetched and mapped into the container. See [Secret](#secrets).
+- `log-driver` - Specifies the log-driver to use in docker. This can be "" (default) or "none". If not equal to "none",
+the `log-args` or the `docker` settings in the [cluster](#cluster-specification) are used.
 
 #### Frontends
 
@@ -198,6 +200,15 @@ The following keys can be specified on a `cluster`.
 used to deploy units to.
 - `instance-count` - The number of machines in the cluster. If this number is higher than the `count` of a task-group,
 different instances of that task-group will be forced on different machines.
+- `docker` - A set of options applied to all docker commands generated for jobs on this cluster.
+- `docker.log-args` - Docker command line arguments related to logging. Uses when `log-driver` is not equal to `none`.
+- `fleet` - A set of options applied to all fleet units generated for jobs on this cluster.
+- `fleet.after` - A list of unit names to add to the [After](https://www.freedesktop.org/software/systemd/man/systemd.unit.html#After=) setting of each unit.
+This list is filtered such that units originating from the same job are excluded.
+- `fleet.wants` - A list of unit names to add to the [Wants](https://www.freedesktop.org/software/systemd/man/systemd.unit.html#Wants=) setting of each unit.
+This list is filtered such that units originating from the same job are excluded.
+- `fleet.requires` - A list of unit names to add to the [Requires](https://www.freedesktop.org/software/systemd/man/systemd.unit.html#Requires=) setting of each unit.
+This list is filtered such that units originating from the same job are excluded.
 
 ## Why is it called J2?
 

--- a/README.md
+++ b/README.md
@@ -187,6 +187,18 @@ cluster "production" {
     stack = "production"
     instance-count = 3
 
+    docker {
+        log-args = ["--log-driver=fluentd", "--log-opt fluentd-address=127.0.0.1:24284"]
+    }
+
+    fleet {
+        after = [
+            "gluon.service",
+            "loggly-fluentd-fluentd-mn.service"
+        ]
+        wants = "loggly-fluentd-fluentd-mn.service"
+    }
+
     default-options {
         "force-ssl" = "true"
     }

--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package flags
+package cluster
 
 import (
 	"fmt"
@@ -22,6 +22,8 @@ import (
 	"github.com/hashicorp/hcl/hcl/ast"
 	"github.com/juju/errgo"
 	"github.com/mitchellh/mapstructure"
+
+	"github.com/pulcy/j2/flags"
 )
 
 const (
@@ -41,7 +43,7 @@ type Cluster struct {
 	// Arguments to add to the docker command for logging
 	DockerLoggingArgs []string `mapstructure:"docker-log-args,omitempty"`
 
-	DefaultOptions Options `mapstructure:"default-options,omitempty"`
+	DefaultOptions flags.Options `mapstructure:"default-options,omitempty"`
 }
 
 // validate checks the values in the given cluster
@@ -140,7 +142,7 @@ func (c *Cluster) parse(list *ast.ObjectList) error {
 			}
 			// Merge key/value pairs into myself
 			for k, v := range m {
-				c.DefaultOptions.set(k, v)
+				c.DefaultOptions.SetKV(k, v)
 			}
 		}
 	}

--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -40,6 +40,9 @@ type Cluster struct {
 	// Docker options
 	DockerOptions DockerOptions
 
+	// Fleet options
+	FleetOptions FleetOptions
+
 	DefaultOptions flags.Options `mapstructure:"default-options,omitempty"`
 }
 

--- a/cluster/docker.go
+++ b/cluster/docker.go
@@ -1,0 +1,26 @@
+// Copyright (c) 2016 Pulcy.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cluster
+
+// DockerOptions contains options used to generate docker commands for the jobs that run on this cluster.
+type DockerOptions struct {
+	// Arguments to add to the docker command for logging
+	LoggingArgs []string `mapstructure:"docker-log-args,omitempty"`
+}
+
+// validate checks the values in the given cluster
+func (do DockerOptions) validate() error {
+	return nil
+}

--- a/cluster/errors.go
+++ b/cluster/errors.go
@@ -1,0 +1,25 @@
+// Copyright (c) 2016 Pulcy.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cluster
+
+import (
+	"github.com/juju/errgo"
+)
+
+var (
+	ValidationError = errgo.New("validation failed")
+
+	maskAny = errgo.MaskFunc(errgo.Any)
+)

--- a/cluster/fleet.go
+++ b/cluster/fleet.go
@@ -1,0 +1,30 @@
+// Copyright (c) 2016 Pulcy.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cluster
+
+// FleetOptions contains options used to generate fleet units for the jobs that run on this cluster.
+type FleetOptions struct {
+	// A list of unit names to add to the `After` setting of all generated units
+	After []string
+	// A list of unit names to add to the `Wants` setting of all generated units
+	Wants []string
+	// A list of unit names to add to the `Requires` setting of all generated units
+	Requires []string
+}
+
+// validate checks the values in the given cluster
+func (o FleetOptions) validate() error {
+	return nil
+}

--- a/cluster/parse.go
+++ b/cluster/parse.go
@@ -1,0 +1,141 @@
+// Copyright (c) 2016 Pulcy.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cluster
+
+import (
+	"fmt"
+	"io/ioutil"
+
+	"github.com/hashicorp/hcl"
+	"github.com/hashicorp/hcl/hcl/ast"
+	"github.com/juju/errgo"
+
+	"github.com/pulcy/j2/util"
+)
+
+// ParseClusterFromFile reads a cluster from file
+func ParseClusterFromFile(path string) (*Cluster, error) {
+	data, err := ioutil.ReadFile(path)
+	if err != nil {
+		return nil, maskAny(err)
+	}
+	// Parse the input
+	root, err := hcl.Parse(string(data))
+	if err != nil {
+		return nil, maskAny(err)
+	}
+	// Top-level item should be a list
+	list, ok := root.Node.(*ast.ObjectList)
+	if !ok {
+		return nil, errgo.New("error parsing: root should be an object")
+	}
+	matches := list.Filter("cluster")
+	if len(matches.Items) == 0 {
+		return nil, errgo.New("'cluster' stanza not found")
+	}
+
+	// Parse hcl into Cluster
+	cluster := &Cluster{}
+	if err := cluster.parse(matches); err != nil {
+		return nil, maskAny(err)
+	}
+	cluster.setDefaults()
+
+	// Validate the cluster
+	if err := cluster.validate(); err != nil {
+		return nil, maskAny(err)
+	}
+
+	return cluster, nil
+}
+
+// Parse a Cluster
+func (c *Cluster) parse(list *ast.ObjectList) error {
+	list = list.Children()
+	if len(list.Items) != 1 {
+		return fmt.Errorf("only one 'cluster' block allowed")
+	}
+
+	// Get our cluster object
+	obj := list.Items[0]
+
+	// Decode the object
+	excludeList := []string{
+		"default-options",
+		"docker",
+	}
+	if err := util.Decode(obj.Val, excludeList, nil, c); err != nil {
+		return maskAny(err)
+	}
+	c.Stack = obj.Keys[0].Token.Value().(string)
+
+	// Value should be an object
+	var listVal *ast.ObjectList
+	if ot, ok := obj.Val.(*ast.ObjectType); ok {
+		listVal = ot.List
+	} else {
+		return errgo.Newf("cluster '%s' value: should be an object", c.Stack)
+	}
+
+	// If we have docker object, parse it
+	if o := listVal.Filter("docker"); len(o.Items) > 0 {
+		for _, o := range o.Elem().Items {
+			if obj, ok := o.Val.(*ast.ObjectType); ok {
+				if err := c.DockerOptions.parse(obj, *c); err != nil {
+					return maskAny(err)
+				}
+			} else {
+				return maskAny(errgo.WithCausef(nil, ValidationError, "docker of cluster '%s' is not an object", c.Stack))
+			}
+		}
+	}
+
+	// Parse default-options
+	if o := listVal.Filter("default-options"); len(o.Items) > 0 {
+		for _, o := range o.Elem().Items {
+			var m map[string]string
+			if err := hcl.DecodeObject(&m, o.Val); err != nil {
+				return maskAny(err)
+			}
+			// Merge key/value pairs into myself
+			for k, v := range m {
+				c.DefaultOptions.SetKV(k, v)
+			}
+		}
+	}
+
+	return nil
+}
+
+// parse a secret
+func (do *DockerOptions) parse(obj *ast.ObjectType, c Cluster) error {
+	// Parse the object
+	excludeList := []string{
+		"log-args",
+	}
+	if err := util.Decode(obj, excludeList, nil, do); err != nil {
+		return maskAny(err)
+	}
+	// Parse log-args
+	if o := obj.List.Filter("log-args"); len(o.Items) > 0 {
+		list, err := util.ParseStringList(o, fmt.Sprintf("log-args of cluster '%s'", c.Stack))
+		if err != nil {
+			return maskAny(err)
+		}
+		do.LoggingArgs = append(do.LoggingArgs, list...)
+	}
+
+	return nil
+}

--- a/deployment.go
+++ b/deployment.go
@@ -23,6 +23,7 @@ import (
 	"github.com/kardianos/osext"
 	"github.com/spf13/pflag"
 
+	"github.com/pulcy/j2/cluster"
 	fg "github.com/pulcy/j2/flags"
 	"github.com/pulcy/j2/jobs"
 )
@@ -80,7 +81,7 @@ func groups(f *fg.Flags) []jobs.TaskGroupName {
 }
 
 // loadJob loads the a job from the given flags.
-func loadJob(f *fg.Flags, cluster fg.Cluster) (*jobs.Job, error) {
+func loadJob(f *fg.Flags, cluster cluster.Cluster) (*jobs.Job, error) {
 	if f.JobPath == "" {
 		return nil, maskAny(errgo.New("--job missing"))
 	}
@@ -96,7 +97,7 @@ func loadJob(f *fg.Flags, cluster fg.Cluster) (*jobs.Job, error) {
 }
 
 // loadCluster loads a cluster description from the given flags.
-func loadCluster(f *fg.Flags) (*fg.Cluster, error) {
+func loadCluster(f *fg.Flags) (*cluster.Cluster, error) {
 	if f.ClusterPath == "" {
 		return nil, maskAny(errgo.New("--cluster missing"))
 	}
@@ -108,7 +109,7 @@ func loadCluster(f *fg.Flags) (*fg.Cluster, error) {
 	if err != nil {
 		return nil, maskAny(err)
 	}
-	cluster, err := fg.ParseClusterFromFile(path)
+	cluster, err := cluster.ParseClusterFromFile(path)
 	if err != nil {
 		return nil, maskAny(err)
 	}

--- a/destroy.go
+++ b/destroy.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/pulcy/j2/cluster"
 	fg "github.com/pulcy/j2/flags"
 	"github.com/pulcy/j2/fleet"
 	"github.com/pulcy/j2/jobs"
@@ -64,7 +65,7 @@ func destroyRun(cmd *cobra.Command, args []string) {
 	}
 }
 
-func destroyValidators(f *fg.Flags, cluster fg.Cluster) {
+func destroyValidators(f *fg.Flags, cluster cluster.Cluster) {
 	j, err := loadJob(f, cluster)
 	if err == nil {
 		f.JobPath = j.Name.String()

--- a/flags/options.go
+++ b/flags/options.go
@@ -53,7 +53,7 @@ func (o *Options) Set(raw string) error {
 	parts := strings.SplitN(raw, "=", 2)
 	if len(parts) == 2 {
 		// Normal key=value
-		o.set(parts[0], parts[1])
+		o.SetKV(parts[0], parts[1])
 		return nil
 	}
 
@@ -66,7 +66,7 @@ func (o *Options) Set(raw string) error {
 	return nil
 }
 
-func (o *Options) set(key, value string) {
+func (o *Options) SetKV(key, value string) {
 	if o.options == nil {
 		o.options = make(map[string]string)
 	}
@@ -100,7 +100,7 @@ func (o *Options) parseFile(path string) error {
 
 	// Merge key/value pairs into myself
 	for k, v := range m {
-		o.set(k, v)
+		o.SetKV(k, v)
 	}
 
 	return nil

--- a/jobs/fleet.go
+++ b/jobs/fleet.go
@@ -1,0 +1,39 @@
+// Copyright (c) 2016 Pulcy.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package jobs
+
+import (
+	"github.com/pulcy/j2/cluster"
+	"github.com/pulcy/j2/units"
+)
+
+// CreateFleetAfter creates a list of unit names to add to the `After` setting of each unit of the given task.
+func (t *Task) AddFleetOptions(fleetOptions cluster.FleetOptions, unit *units.Unit) {
+	unit.ExecOptions.After(t.group.job.excludeUnitsOfJob(fleetOptions.After)...)
+	unit.ExecOptions.Want(t.group.job.excludeUnitsOfJob(fleetOptions.Wants)...)
+	unit.ExecOptions.Require(t.group.job.excludeUnitsOfJob(fleetOptions.Requires)...)
+}
+
+// excludeUnitsOfJob creates a copy of the given unit names list, excluding those unit names that
+// belong to the given job.
+func (j *Job) excludeUnitsOfJob(unitNames []string) []string {
+	result := []string{}
+	for _, unitName := range unitNames {
+		if !IsUnitForJob(unitName, j.Name) {
+			result = append(result, unitName)
+		}
+	}
+	return result
+}

--- a/jobs/functions.go
+++ b/jobs/functions.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/juju/errgo"
 
+	"github.com/pulcy/j2/cluster"
 	fg "github.com/pulcy/j2/flags"
 )
 
@@ -36,11 +37,11 @@ const (
 type jobFunctions struct {
 	jobPath string
 	options fg.Options
-	cluster fg.Cluster
+	cluster cluster.Cluster
 }
 
 // newJobFunctions creates a new instance of jobFunctions
-func newJobFunctions(jobPath string, cluster fg.Cluster, options fg.Options) *jobFunctions {
+func newJobFunctions(jobPath string, cluster cluster.Cluster, options fg.Options) *jobFunctions {
 	absJobPath, _ := filepath.Abs(jobPath)
 	return &jobFunctions{
 		jobPath: absJobPath,

--- a/jobs/job.go
+++ b/jobs/job.go
@@ -80,8 +80,8 @@ func (j *Job) Validate() error {
 	return nil
 }
 
-func (j *Job) Generate(groups []TaskGroupName, currentScalingGroup uint, clusterDockerLoggingArgs []string) *Generator {
-	return newGenerator(j, groups, currentScalingGroup, clusterDockerLoggingArgs)
+func (j *Job) Generate(config GeneratorConfig) *Generator {
+	return newGenerator(j, config)
 }
 
 func (j *Job) MaxCount() uint {

--- a/jobs/logging.go
+++ b/jobs/logging.go
@@ -16,6 +16,8 @@ package jobs
 
 import (
 	"fmt"
+
+	"github.com/pulcy/j2/cluster"
 )
 
 type LogDriver string
@@ -39,10 +41,10 @@ func (lg LogDriver) Validate() error {
 
 // CreateDockerLogArgs creates a series of command line arguments for the given
 // log driver, based on the given cluster.
-func (lg LogDriver) CreateDockerLogArgs(clusterDockerLoggingArgs []string) []string {
+func (lg LogDriver) CreateDockerLogArgs(dockerOptions cluster.DockerOptions) []string {
 	switch lg {
 	case "": // Default from cluster
-		return clusterDockerLoggingArgs
+		return dockerOptions.LoggingArgs
 	case "none":
 		return nil
 	default:

--- a/jobs/parse.go
+++ b/jobs/parse.go
@@ -26,11 +26,12 @@ import (
 	"github.com/juju/errgo"
 	"github.com/mitchellh/mapstructure"
 
+	"github.com/pulcy/j2/cluster"
 	fg "github.com/pulcy/j2/flags"
 )
 
 type parseJobOptions struct {
-	Cluster fg.Cluster
+	Cluster cluster.Cluster
 }
 
 // ParseJob takes input from a given reader and parses it into a Job.
@@ -81,7 +82,7 @@ func parseJob(input []byte, opts parseJobOptions, jf *jobFunctions) (*Job, error
 }
 
 // ParseJobFromFile reads a job from file
-func ParseJobFromFile(path string, cluster fg.Cluster, options fg.Options) (*Job, error) {
+func ParseJobFromFile(path string, cluster cluster.Cluster, options fg.Options) (*Job, error) {
 	data, err := ioutil.ReadFile(path)
 	if err != nil {
 		return nil, maskAny(err)

--- a/jobs/task.go
+++ b/jobs/task.go
@@ -33,7 +33,6 @@ const (
 var (
 	commonAfter = []string{
 		"docker.service",
-		"yard.service",
 	}
 	commonRequires = []string{
 		"docker.service",

--- a/jobs/task_create_main.go
+++ b/jobs/task_create_main.go
@@ -177,7 +177,7 @@ func (t *Task) createMainDockerCmdLine(ctx generatorContext) ([]string, map[stri
 	for _, ln := range t.Links {
 		addArg(fmt.Sprintf("--add-host %s:${COREOS_PRIVATE_IPV4}", ln.PrivateDomainName()))
 	}
-	for _, arg := range t.LogDriver.CreateDockerLogArgs(ctx.ClusterDockerLoggingArgs) {
+	for _, arg := range t.LogDriver.CreateDockerLogArgs(ctx.DockerOptions) {
 		addArg(arg)
 	}
 	execStart = append(execStart, t.DockerArgs...)

--- a/jobs/task_create_main.go
+++ b/jobs/task_create_main.go
@@ -109,6 +109,8 @@ func (t *Task) createMainUnit(ctx generatorContext) (*units.Unit, error) {
 		return nil, maskAny(err)
 	}
 
+	t.AddFleetOptions(ctx.FleetOptions, main)
+
 	return main, nil
 }
 

--- a/jobs/task_create_secrets.go
+++ b/jobs/task_create_secrets.go
@@ -152,6 +152,8 @@ func (t *Task) createSecretsUnit(ctx generatorContext) (*units.Unit, error) {
 		return nil, maskAny(err)
 	}
 
+	t.AddFleetOptions(ctx.FleetOptions, unit)
+
 	return unit, nil
 }
 

--- a/jobs/task_create_secrets.go
+++ b/jobs/task_create_secrets.go
@@ -63,7 +63,7 @@ func (t *Task) createSecretsUnit(ctx generatorContext) (*units.Unit, error) {
 				"-v", "${VOLMAC}",
 				"--env-file", "/etc/pulcy/vault.env",
 			}
-			for _, arg := range t.LogDriver.CreateDockerLogArgs(ctx.ClusterDockerLoggingArgs) {
+			for _, arg := range t.LogDriver.CreateDockerLogArgs(ctx.DockerOptions) {
 				addArg(arg, &cmd)
 			}
 			cmd = append(cmd,
@@ -92,7 +92,7 @@ func (t *Task) createSecretsUnit(ctx generatorContext) (*units.Unit, error) {
 			"-v", "${VOLMAC}",
 			"--env-file", "/etc/pulcy/vault.env",
 		}
-		for _, arg := range t.LogDriver.CreateDockerLogArgs(ctx.ClusterDockerLoggingArgs) {
+		for _, arg := range t.LogDriver.CreateDockerLogArgs(ctx.DockerOptions) {
 			addArg(arg, &cmd)
 		}
 		cmd = append(cmd,

--- a/jobs/task_create_timer.go
+++ b/jobs/task_create_timer.go
@@ -38,5 +38,7 @@ func (t *Task) createTimerUnit(ctx generatorContext) (*units.Unit, error) {
 	unit.ExecOptions.OnCalendar = t.Timer
 	unit.ExecOptions.Unit = t.unitName(unitKindMain, strconv.Itoa(int(ctx.ScalingGroup))) + ".service"
 
+	t.AddFleetOptions(ctx.FleetOptions, unit)
+
 	return unit, nil
 }

--- a/run.go
+++ b/run.go
@@ -26,6 +26,7 @@ import (
 
 	fg "github.com/pulcy/j2/flags"
 	"github.com/pulcy/j2/fleet"
+	"github.com/pulcy/j2/jobs"
 	"github.com/pulcy/j2/units"
 )
 
@@ -64,8 +65,12 @@ func runRun(cmd *cobra.Command, args []string) {
 		Exitf("Cannot load job: %v\n", err)
 	}
 
-	groups := groups(&runFlags.Flags)
-	generator := job.Generate(groups, runFlags.ScalingGroup, cluster.DockerLoggingArgs)
+	generatorConfig := jobs.GeneratorConfig{
+		Groups:              groups(&runFlags.Flags),
+		CurrentScalingGroup: runFlags.ScalingGroup,
+		DockerOptions:       cluster.DockerOptions,
+	}
+	generator := job.Generate(generatorConfig)
 	assert(generator.WriteTmpFiles(ctx, images, cluster.InstanceCount))
 
 	if runFlags.DryRun {
@@ -74,7 +79,8 @@ func runRun(cmd *cobra.Command, args []string) {
 		location := cluster.Stack
 		count := job.MaxCount()
 		updateScalingGroups(&runFlags.ScalingGroup, count, location, func(runUpdate runUpdateCallback) {
-			generator := job.Generate(groups, runFlags.ScalingGroup, cluster.DockerLoggingArgs)
+			generatorConfig.CurrentScalingGroup = runFlags.ScalingGroup
+			generator := job.Generate(generatorConfig)
 
 			assert(generator.WriteTmpFiles(ctx, images, cluster.InstanceCount))
 

--- a/run.go
+++ b/run.go
@@ -69,6 +69,7 @@ func runRun(cmd *cobra.Command, args []string) {
 		Groups:              groups(&runFlags.Flags),
 		CurrentScalingGroup: runFlags.ScalingGroup,
 		DockerOptions:       cluster.DockerOptions,
+		FleetOptions:        cluster.FleetOptions,
 	}
 	generator := job.Generate(generatorConfig)
 	assert(generator.WriteTmpFiles(ctx, images, cluster.InstanceCount))

--- a/units/options.go
+++ b/units/options.go
@@ -38,7 +38,7 @@ type execOptions struct {
 	ExecStop                []string
 	ExecStopPost            []string
 	BindsTos                []string
-	Wants                   string
+	wants                   []string
 	after                   []string
 	Requires                []string
 
@@ -86,6 +86,10 @@ func (e *execOptions) After(after ...string) {
 
 func (e *execOptions) Require(require ...string) {
 	e.Requires = append(e.Requires, require...)
+}
+
+func (e *execOptions) Want(want ...string) {
+	e.wants = append(e.wants, want...)
 }
 
 type fleetOptions struct {

--- a/units/render.go
+++ b/units/render.go
@@ -32,8 +32,8 @@ func (u *Unit) Render(ctx RenderContext) string {
 		"[Unit]",
 		"Description=" + u.Description,
 	}
-	if u.ExecOptions.Wants != "" {
-		lines = append(lines, "Wants="+u.ExecOptions.Wants)
+	for _, x := range u.ExecOptions.wants {
+		lines = append(lines, "Wants="+x)
 	}
 	for _, x := range u.ExecOptions.Requires {
 		lines = append(lines, "Requires="+x)

--- a/units/render.go
+++ b/units/render.go
@@ -32,16 +32,16 @@ func (u *Unit) Render(ctx RenderContext) string {
 		"[Unit]",
 		"Description=" + u.Description,
 	}
-	for _, x := range u.ExecOptions.wants {
+	for _, x := range distinct(u.ExecOptions.wants) {
 		lines = append(lines, "Wants="+x)
 	}
-	for _, x := range u.ExecOptions.Requires {
+	for _, x := range distinct(u.ExecOptions.Requires) {
 		lines = append(lines, "Requires="+x)
 	}
-	for _, x := range u.ExecOptions.BindsTos {
+	for _, x := range distinct(u.ExecOptions.BindsTos) {
 		lines = append(lines, "BindsTo="+x)
 	}
-	for _, x := range u.ExecOptions.after {
+	for _, x := range distinct(u.ExecOptions.after) {
 		lines = append(lines, "After="+x)
 	}
 	lines = append(lines, "")
@@ -106,7 +106,7 @@ func (u *Unit) Render(ctx RenderContext) string {
 	if u.FleetOptions.IsGlobal {
 		lines = append(lines, "Global=true")
 	}
-	for _, x := range u.FleetOptions.ConflictsWith {
+	for _, x := range distinct(u.FleetOptions.ConflictsWith) {
 		lines = append(lines, "Conflicts="+x)
 	}
 	if u.FleetOptions.MachineOf != "" {
@@ -115,7 +115,7 @@ func (u *Unit) Render(ctx RenderContext) string {
 	if u.FleetOptions.MachineID != "" {
 		lines = append(lines, "MachineID="+u.FleetOptions.MachineID)
 	}
-	for _, x := range u.FleetOptions.Metadata {
+	for _, x := range distinct(u.FleetOptions.Metadata) {
 		lines = append(lines, "MachineMetadata="+x)
 	}
 	lines = append(lines, "")
@@ -130,4 +130,18 @@ func (u *Unit) Render(ctx RenderContext) string {
 	lines = append(lines, "")
 
 	return strings.Join(lines, "\n")
+}
+
+// distinct returns a list with all distinct values of the given list
+func distinct(list []string) []string {
+	result := []string{}
+	seen := make(map[string]struct{})
+	for _, x := range list {
+		if _, ok := seen[x]; ok {
+			continue
+		}
+		result = append(result, x)
+		seen[x] = struct{}{}
+	}
+	return result
 }

--- a/util/error.go
+++ b/util/error.go
@@ -1,0 +1,25 @@
+// Copyright (c) 2016 Pulcy.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import (
+	"github.com/juju/errgo"
+)
+
+var (
+	ValidationError = errgo.New("validation failed")
+
+	maskAny = errgo.MaskFunc(errgo.Any)
+)

--- a/util/hcl.go
+++ b/util/hcl.go
@@ -1,0 +1,70 @@
+// Copyright (c) 2016 Pulcy.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import (
+	"github.com/hashicorp/hcl"
+	"github.com/hashicorp/hcl/hcl/ast"
+	"github.com/hashicorp/hcl/hcl/token"
+	"github.com/juju/errgo"
+	"github.com/mitchellh/mapstructure"
+)
+
+func ParseStringList(o *ast.ObjectList, context string) ([]string, error) {
+	result := []string{}
+	for _, o := range o.Elem().Items {
+		if olit, ok := o.Val.(*ast.LiteralType); ok && olit.Token.Type == token.STRING {
+			result = append(result, olit.Token.Value().(string))
+		} else if list, ok := o.Val.(*ast.ListType); ok {
+			for _, n := range list.List {
+				if olit, ok := n.(*ast.LiteralType); ok && olit.Token.Type == token.STRING {
+					result = append(result, olit.Token.Value().(string))
+				} else {
+					return nil, maskAny(errgo.WithCausef(nil, ValidationError, "element of %s is not a string but %v", context, n))
+				}
+			}
+		} else {
+			return nil, maskAny(errgo.WithCausef(nil, ValidationError, "%s is not a string or array", context))
+		}
+	}
+	return result, nil
+}
+
+// Decode from object to data structure using `mapstructure`
+func Decode(obj ast.Node, excludeKeys []string, defaultValues map[string]interface{}, data interface{}) error {
+	var m map[string]interface{}
+	if err := hcl.DecodeObject(&m, obj); err != nil {
+		return maskAny(err)
+	}
+	for _, key := range excludeKeys {
+		delete(m, key)
+	}
+	for k, v := range defaultValues {
+		if _, ok := m[k]; !ok {
+			m[k] = v
+		}
+	}
+	decoderConfig := &mapstructure.DecoderConfig{
+		ErrorUnused:      true,
+		WeaklyTypedInput: true,
+		Metadata:         nil,
+		Result:           data,
+	}
+	decoder, err := mapstructure.NewDecoder(decoderConfig)
+	if err != nil {
+		return maskAny(err)
+	}
+	return maskAny(decoder.Decode(m))
+}


### PR DESCRIPTION
Extended cluster functionality.

- Added `docker` object to cluster files 
- Added `fleet` object to cluster files 
- Added `after`, `wants`, `requires` options (to cluster files) which are added to all units generated for that cluster (units resulting from the same job are excluded)

Example cluster file:
```
cluster "prod" {
    domain = "pulcy.com"
    stack = "test-feb2"
    instance-count = 3

    docker {
        log-args = ["--log-driver=fluentd", "--log-opt fluentd-address=127.0.0.1:24284"]
    }

    fleet {
        after = [
            "gluon.service",
            "loggly-fluentd-fluentd-mn.service"
        ]
        wants = "loggly-fluentd-fluentd-mn.service"
    }

    default-options {
        "force-ssl" = "true"
    }
}
```