### PR TITLE
Support count>1 with global=true

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,11 @@ This list is filtered such that units originating from the same job are excluded
 This list is filtered such that units originating from the same job are excluded.
 - `fleet.requires` - A list of unit names to add to the [Requires](https://www.freedesktop.org/software/systemd/man/systemd.unit.html#Requires=) setting of each unit.
 This list is filtered such that units originating from the same job are excluded.
+- `fleet.global-instance-constraints` - A list of metadata constraints. One of them is added to an instance of a global
+unit with a `count` higher than 1.
+For example with `global-instance-constraints = ["global=1", "global=2"]` instance 1 will get `global=1` and instance 2
+will get `global=2` as metadata. You can choose how to spread these metadata's across the machines of the cluster, but make
+sure that every machine has `global=1` OR `global=2` in its metadata and not both.
 
 ## Why is it called J2?
 

--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -75,4 +75,5 @@ func (c *Cluster) setDefaults() {
 	if c.InstanceCount == 0 {
 		c.InstanceCount = defaultInstanceCount
 	}
+	c.FleetOptions.setDefaults()
 }

--- a/cluster/fleet.go
+++ b/cluster/fleet.go
@@ -22,9 +22,20 @@ type FleetOptions struct {
 	Wants []string
 	// A list of unit names to add to the `Requires` setting of all generated units
 	Requires []string
+
+	GlobalInstanceConstraints []string
 }
 
 // validate checks the values in the given cluster
 func (o FleetOptions) validate() error {
 	return nil
+}
+
+func (o *FleetOptions) setDefaults() {
+	if len(o.GlobalInstanceConstraints) == 0 {
+		o.GlobalInstanceConstraints = []string{
+			"odd=true",
+			"even=true",
+		}
+	}
 }

--- a/cluster/parse.go
+++ b/cluster/parse.go
@@ -161,6 +161,7 @@ func (options *FleetOptions) parse(obj *ast.ObjectType, c Cluster) error {
 		"after",
 		"wants",
 		"requires",
+		"global-instance-constraints",
 	}
 	if err := util.Decode(obj, excludeList, nil, options); err != nil {
 		return maskAny(err)
@@ -188,6 +189,15 @@ func (options *FleetOptions) parse(obj *ast.ObjectType, c Cluster) error {
 			return maskAny(err)
 		}
 		options.Requires = list
+	}
+
+	// Parse global-instance-constraints
+	if o := obj.List.Filter("global-instance-constraints"); len(o.Items) > 0 {
+		list, err := util.ParseStringList(o, fmt.Sprintf("global-instance-constraints of cluster '%s'", c.Stack))
+		if err != nil {
+			return maskAny(err)
+		}
+		options.GlobalInstanceConstraints = list
 	}
 
 	return nil

--- a/config/base.hcl
+++ b/config/base.hcl
@@ -10,6 +10,7 @@ job "base" {
 
 	group "load_balancer" {
 		global = true
+		count = 2 // This splits the instances of the tasks up into 2 groups, 50% of the machines get one group, the other 50% the rest.
 
 		task "certificates" {
 			type = "oneshot"

--- a/jobs/task.go
+++ b/jobs/task.go
@@ -167,7 +167,7 @@ func (t *Task) instanceSpecificPrivateDomainName(scalingGroup uint) string {
 // unitName returns the name of the systemd unit for this task.
 func (t *Task) unitName(kind string, scalingGroup string) string {
 	base := strings.Replace(t.fullName(), "/", "-", -1) + kind
-	if !t.group.IsScalable() {
+	if t.group.Global && t.group.Count == 1 {
 		return base
 	}
 	return fmt.Sprintf("%s@%s", base, scalingGroup)
@@ -185,7 +185,7 @@ func (t *Task) unitDescription(prefix string, scalingGroup uint) string {
 // containerName returns the name of the docker contained used for this task.
 func (t *Task) containerName(scalingGroup uint) string {
 	base := strings.Replace(t.fullName(), "/", "-", -1)
-	if !t.group.IsScalable() {
+	if t.group.Global {
 		return base
 	}
 	return fmt.Sprintf("%s-%v", base, scalingGroup)

--- a/jobs/task_create_timer.go
+++ b/jobs/task_create_timer.go
@@ -30,7 +30,7 @@ func (t *Task) createTimerUnit(ctx generatorContext) (*units.Unit, error) {
 		FullName:     t.unitName(unitKindTimer, strconv.Itoa(int(ctx.ScalingGroup))) + ".timer",
 		Description:  t.unitDescription("Timer", ctx.ScalingGroup),
 		Type:         "timer",
-		Scalable:     t.group.IsScalable(),
+		Scalable_:    false, //    t.group.IsScalable(),
 		ScalingGroup: ctx.ScalingGroup,
 		ExecOptions:  units.NewExecOptions(),
 		FleetOptions: units.NewFleetOptions(),

--- a/jobs/taskgroup.go
+++ b/jobs/taskgroup.go
@@ -74,8 +74,8 @@ func (tg *TaskGroup) Validate() error {
 	if err := tg.Name.Validate(); err != nil {
 		return maskAny(err)
 	}
-	if tg.Count == 0 {
-		return maskAny(errgo.WithCausef(nil, ValidationError, "group %s count 0", tg.Name))
+	if tg.Count <= 0 {
+		return maskAny(errgo.WithCausef(nil, ValidationError, "group %s count <= 0", tg.Name))
 	}
 	if len(tg.Tasks) == 0 {
 		return maskAny(errgo.WithCausef(nil, ValidationError, "group %s has no tasks", tg.Name))
@@ -109,20 +109,14 @@ func (tg *TaskGroup) Task(name TaskName) (*Task, error) {
 
 // Is this group scalable?
 // That mean "not global"
-func (tg *TaskGroup) IsScalable() bool {
+/*func (tg *TaskGroup) IsScalable() bool {
 	return !tg.Global
-}
+}*/
 
 // createUnits creates all units needed to run this taskgroup.
 func (tg *TaskGroup) createUnits(ctx generatorContext) ([]units.UnitChain, error) {
-	if tg.Global {
-		if ctx.ScalingGroup != 1 {
-			return nil, nil
-		}
-	} else {
-		if ctx.ScalingGroup > tg.Count {
-			return nil, nil
-		}
+	if ctx.ScalingGroup > tg.Count {
+		return nil, nil
 	}
 
 	// Create all units for my tasks

--- a/units/unit.go
+++ b/units/unit.go
@@ -19,7 +19,7 @@ type Unit struct {
 	FullName        string // e.g. "foo@1.service"
 	Type            string "service|socket|timer"
 	Description     string
-	Scalable        bool
+	Scalable_       bool
 	ScalingGroup    uint
 	ExecOptions     *execOptions
 	FleetOptions    *fleetOptions


### PR DESCRIPTION
This change adds support for splitting all instances of global task (groups) into sets with the intention that during an update of a global task group, some of the instances keep running at all times.